### PR TITLE
Fix Dismiss alarm app (clear)

### DIFF
--- a/awtrix_ukraine_alarm.yaml
+++ b/awtrix_ukraine_alarm.yaml
@@ -212,5 +212,6 @@ action:
         data:
           retain: false
           topic: "{{ app_topic }}"
+          payload: ""
         alias: Dismiss alarm app (clear)
 mode: single


### PR DESCRIPTION
An updated Home Assistant now throws an error:
```
Error: required key not provided @ data['payload']
```

Adding an empty payload fixes this.